### PR TITLE
Fix German language error string

### DIFF
--- a/locale/de/directory.locale.inc.php
+++ b/locale/de/directory.locale.inc.php
@@ -46,5 +46,5 @@
  define ('PB_BOOKS_ERROR', 'Fehler');
  define ('PB_BOOKS_ADMIN_CHECK_FOLDER_RIGHTS', "Administrator: Bitte Schreibrechte für '/books' prüfen.");
  define ('PB_BOOKS_ADMIN_CHECK_LIBCURL', "Administrator: Die Biblithek 'libcurl' steht nicht zur Verfügung.");
- define ('PB_BOOKS_ADMIN_CHECK_MBSTRING', "Administrator: Die Erweiterung bzw. das Modul 'libcurl' steht nicht zur Verfügung.");
+ define ('PB_BOOKS_ADMIN_CHECK_MBSTRING', "Administrator: Die Erweiterung bzw. das Modul 'mbstring' steht nicht zur Verfügung.");
 ?>


### PR DESCRIPTION
PB_BOOKS_ADMIN_CHECK_MBSTRING erroneously said that `libcurl` was missing.